### PR TITLE
Test: Add explicit verification for soft-deleted data visibility

### DIFF
--- a/src/test/java/database/impl/CategoryDAOImplTest.java
+++ b/src/test/java/database/impl/CategoryDAOImplTest.java
@@ -66,4 +66,23 @@ class CategoryDAOImplTest extends BaseIntegrationTest {
         Optional<Category> found = dao.findById(999);
         assertFalse(found.isPresent());
     }
+
+    @Test
+    @DisplayName("論理削除されたカテゴリが一覧に含まれないこと")
+    void testSoftDelete_Visibility() {
+        String name = "削除用カテゴリ";
+        dao.insert(name, "test-user");
+
+        Category inserted = dao.findAll().stream()
+                .filter(c -> name.equals(c.name()))
+                .findFirst()
+                .orElseThrow();
+
+        // 論理削除
+        assertTrue(dao.softDelete(inserted.id(), "test-user"));
+
+        // findAll から除外されていること
+        List<Category> allCategories = dao.findAll();
+        assertFalse(allCategories.stream().anyMatch(c -> c.id() == inserted.id()));
+    }
 }

--- a/src/test/java/database/impl/ProductDAOImplTest.java
+++ b/src/test/java/database/impl/ProductDAOImplTest.java
@@ -71,4 +71,27 @@ public class ProductDAOImplTest extends BaseIntegrationTest {
         assertTrue(productDAO.updateAvailability(inserted.id(), true, "admin"));
         assertTrue(productDAO.findById(inserted.id()).get().isAvailable());
     }
+
+    @Test
+    void testSoftDelete_Visibility() {
+        Product p = new Product(0, 1, "Deleted Product", 1000, "Desc", "None", null, true, false);
+        assertTrue(productDAO.insert(p, "admin"));
+
+        // 最新のものを取得
+        List<Product> list = productDAO.findAll();
+        Product inserted = list.stream()
+                .filter(item -> "Deleted Product".equals(item.name()))
+                .findFirst().get();
+
+        // 論理削除
+        assertTrue(productDAO.softDelete(inserted.id(), "admin"));
+
+        // findAll から除外されていること
+        List<Product> allProducts = productDAO.findAll();
+        assertFalse(allProducts.stream().anyMatch(item -> item.id() == inserted.id()));
+
+        // findByCategory からも除外されていること
+        List<Product> categoryProducts = productDAO.findByCategory(1);
+        assertFalse(categoryProducts.stream().anyMatch(item -> item.id() == inserted.id()));
+    }
 }

--- a/src/test/java/database/impl/TableDAOImplTest.java
+++ b/src/test/java/database/impl/TableDAOImplTest.java
@@ -56,4 +56,23 @@ class TableDAOImplTest extends BaseIntegrationTest {
         assertNotNull(unsettled);
         assertEquals(0, unsettled.size());
     }
+
+    @Test
+    @DisplayName("論理削除されたテーブルが一覧に含まれないこと")
+    void testSoftDelete_Visibility() {
+        String name = "削除用テーブル";
+        dao.insert(name, "test-user");
+
+        TableStatusView inserted = dao.findAllTableStatus().stream()
+                .filter(t -> name.equals(t.tableName()))
+                .findFirst()
+                .orElseThrow();
+
+        // 論理削除
+        assertTrue(dao.softDelete(inserted.tableId(), "test-user"));
+
+        // findAllTableStatus から除外されていること
+        List<TableStatusView> allStatuses = dao.findAllTableStatus();
+        assertFalse(allStatuses.stream().anyMatch(t -> t.tableId() == inserted.tableId()));
+    }
 }

--- a/src/test/java/database/impl/UserDAOImplTest.java
+++ b/src/test/java/database/impl/UserDAOImplTest.java
@@ -81,4 +81,24 @@ public class UserDAOImplTest extends BaseIntegrationTest {
         assertTrue(userDAO.delete(userId));
         assertFalse(userDAO.findById(userId).isPresent());
     }
+
+    @Test
+    void testSoftDelete_Visibility() {
+        String userId = "deleted_user";
+        User user = new User(userId, "pass", 1, null, false);
+        userDAO.insert(user, "admin");
+
+        // 論理削除実行
+        assertTrue(userDAO.softDelete(userId, "admin"));
+
+        // findById では取得できる（管理画面等での参照用）
+        Optional<User> found = userDAO.findById(userId);
+        assertTrue(found.isPresent());
+        assertTrue(found.get().isDeleted());
+
+        // findAll では除外されていることを確認
+        List<User> allUsers = userDAO.findAll();
+        boolean exists = allUsers.stream().anyMatch(u -> u.id().equals(userId));
+        assertFalse(exists, "論理削除されたユーザーが一覧に含まれています");
+    }
 }


### PR DESCRIPTION
概要 #fixs#5
論理削除（ソフトデリート）されたデータが、一覧取得メソッドの結果に正しく含まれないことを明示的に検証するテストケースを主要なDAOに追加しました。

追加したテストケース
以下のDAOテストにおいて、testSoftDelete_Visibility シナリオを追加しました：

UserDAOImplTest: ユーザーの論理削除後、findAll() の結果から除外されていることを確認。
ProductDAOImplTest: 商品の論理削除後、findAll() および findByCategory() の結果から除外されていることを確認。
CategoryDAOImplTest: カテゴリの論理削除後、findAll() の結果から除外されていることを確認。
TableDAOImplTest: 座席の論理削除後、findAllTableStatus() の結果から除外されていることを確認。
修正内容
TableStatusView レコードにおいて、IDを取得するアクセサメソッドが id() ではなく tableId() であったため、テストコードを修正しました。
検証結果
mvn test: 全285テストが正常にパスすることを確認済みです。